### PR TITLE
Update toggl's API url

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 # Proxy Toggl api to avoid CORS
 [[redirects]]
   from = "/api/*"
-  to = "https://www.toggl.com/api/v8/:splat"
+  to = "https://api.track.toggl.com/api/v8/:splat"
   status = 200
 
 [[redirects]]


### PR DESCRIPTION
Using the API from toggl.com or www.toggl.com will be dropped at The End of June 2021. Switch to api.track.toggl.com